### PR TITLE
fix the problem aobut default charset is not utf8 while mocking data

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -22,6 +22,8 @@ func InitDB() *gorm.DB {
 		fmt.Print("\n\n------------------------------------------ GORM OPEN SUCCESS! -----------------------------------------------\n\n")
 	}
 
+	db = db.Set("gorm:table_options", "ENGINE=InnoDB  DEFAULT CHARSET=utf8;").AutoMigrate()
+
 	db.LogMode(config.DBConfig.Debug)
 	DB = db
 


### PR DESCRIPTION
创建DB链接的url中的charset没有生效，导致mock创建出来的statuses表中的context字段的默认编码是latin1而不是utf8。这样的话，微博发布内容如果有中文的话，会乱码。
当然，如果手动修改数据库的相关字段编码为UTF8的话，也能解决问题，但是项目初级使用者会比较难定位问题。