### PR TITLE
解决mock数据不能DropTable的问题和创建表默认编码问题

### DIFF
--- a/app/models/user/user.go
+++ b/app/models/user/user.go
@@ -1,16 +1,15 @@
 package user
 
 import (
-  "time"
-  "gin_weibo/app/models"
+	"gin_weibo/app/models"
+	"time"
 )
-
 
 // User 用户模型
 type User struct {
 	models.BaseModel
 	Name     string `gorm:"column:name;type:varchar(255);not null"`
-	Email    string `gorm:"column:email;type:varchar(255);unique;not null"`
+	Email    string `gorm:"column:email;type:varchar(190);unique;not null"` // 如果采用utf8mb4编码，那么没个字符占用4个字节，索引（unique）最大空间767，所以字段长度最大为191
 	Avatar   string `gorm:"column:avatar;type:varchar(255);not null"`
 	Password string `gorm:"column:password;type:varchar(255);not null"`
 	// 是否为管理员

--- a/database/database.go
+++ b/database/database.go
@@ -22,8 +22,6 @@ func InitDB() *gorm.DB {
 		fmt.Print("\n\n------------------------------------------ GORM OPEN SUCCESS! -----------------------------------------------\n\n")
 	}
 
-	db = db.Set("gorm:table_options", "ENGINE=InnoDB  DEFAULT CHARSET=utf8;").AutoMigrate()
-
 	db.LogMode(config.DBConfig.Debug)
 	DB = db
 

--- a/database/factory/factory.go
+++ b/database/factory/factory.go
@@ -7,5 +7,5 @@ import (
 // DropAndCreateTable - 清空表
 func DropAndCreateTable(table interface{}) {
 	database.DB.DropTable(table)
-	database.DB.CreateTable(table)
+	database.DB.Set("gorm:table_options", "ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4;").CreateTable(table)
 }


### PR DESCRIPTION
上次修复编码问题时，因为测试不全面，引入了重新mock时，不能DropTable的问题。
此次修复主要修改了设置默认编码的时机，由之前的AutoMigrate改为现在的CreateTable；但是引入了一个新问题，就是默认编码如果是utf8mb4的话，一个字符占用4个字节，这样users表中的唯一索引字段的长度会超出默认值。所以更改了users.email字段的长度。
问题解释详见：https://stackoverflow.com/questions/1814532/1071-specified-key-was-too-long-max-key-length-is-767-bytes